### PR TITLE
[BugFix] 結果の文章がはみ出す不具合を修正

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -63,7 +63,7 @@ p {
 
 .main .output {
   width: 800px;
-  height: 200px;
+  min-height: 200px;
   padding: 10px;
   text-align: left;
 }
@@ -105,6 +105,13 @@ p {
   .main .input,
   .main .output {
     width: 95%;
+  }
+
+  .main .input {
     height: 150px;
+  }
+
+  .main .output {
+    min-height: 150px;
   }
 }

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -64,8 +64,10 @@ p {
 .main .output {
   width: 800px;
   min-height: 200px;
+  max-height: 400px;
   padding: 10px;
   text-align: left;
+  overflow-y: auto;
 }
 
 .main .canvas {
@@ -113,5 +115,6 @@ p {
 
   .main .output {
     min-height: 150px;
+    max-height: 300px;
   }
 }


### PR DESCRIPTION
## 概要
Outputエリアの高さ設定が原因で、文章がはみ出す不具合が出ていたので修正しました。

## スクリーンショット
| PC / タブレット表示 | スマホ表示 |
| ------ | ---------- |
|![localhost_5173_(iPad Pro)](https://github.com/arkwnet/569/assets/39184410/bd51a51b-7ec1-48a4-b65d-12766b5d82dc)|![localhost_5173_(iPhone SE) (2)](https://github.com/arkwnet/569/assets/39184410/4be43a7a-1ff2-4381-8181-f2836225989f)|
